### PR TITLE
Add workflow for auto adding PRs and issues to FS project board

### DIFF
--- a/files/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,27 @@
+# This file is authored in FilOzone/github-mgmt repository and copied to other repos.
+# If you need to make changes, either:
+# 1. Make the changes in FilOzone/github-mgmt repository OE
+# 2. Make the changes in the local repo and remove the copying from github-mgmt.
+
+# This action adds all issues and PRs to the FS project board.
+# It is used to keep the project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and prs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}

--- a/files/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,11 +1,16 @@
-# This file is authored in FilOzone/github-mgmt repository and copied to other repos.
+######################################################################################
+# READ THIS FIRST
+# This file is authored in FilOzone/github-mgmt repository and copied to other repos via automation.
 # If you need to make changes, either:
-# 1. Make the changes in FilOzone/github-mgmt repository OE
-# 2. Make the changes in the local repo and remove the copying from github-mgmt.
+# 1. Make the changes in FilOzone/github-mgmt repository OR
+# 2. Make the changes in the local repo and remove the automated copying from github-mgmt.
+######################################################################################
 
 # This action adds all issues and PRs to the FS project board.
 # It is used to keep the project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
 name: Add issues and PRs to FS project board
 
 on:

--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -165,6 +165,9 @@ repositories:
         - lordshashank
         - rvagg
         - silent-cipher
+    files: 
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -189,6 +192,9 @@ repositories:
         - rvagg
       push:
         - silent-cipher
+    files: 
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
     merge_commit_message: PR_BODY
     merge_commit_title: PR_TITLE
@@ -382,6 +388,9 @@ repositories:
         - frrist
         - LexLuthr
         - nijoe1
+    files: 
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -455,6 +464,9 @@ repositories:
         - silent-cipher
         - timfong888
         - TippyFlitsUK
+    files: 
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -165,7 +165,7 @@ repositories:
         - lordshashank
         - rvagg
         - silent-cipher
-    files: 
+    files:
       .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
         content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
@@ -192,7 +192,7 @@ repositories:
         - rvagg
       push:
         - silent-cipher
-    files: 
+    files:
       .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
         content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
@@ -388,7 +388,7 @@ repositories:
         - frrist
         - LexLuthr
         - nijoe1
-    files: 
+    files:
       .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
         content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false
@@ -464,7 +464,7 @@ repositories:
         - silent-cipher
         - timfong888
         - TippyFlitsUK
-    files: 
+    files:
       .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
         content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: false


### PR DESCRIPTION
This is part of https://github.com/FilOzone/github-mgmt/issues/10

This adds the workflow to

- https://github.com/FilOzone/synapse-sdk
- https://github.com/FilOzone/pdp
- https://github.com/FilOzone/filecoin-services
- https://github.com/FilOzone/filecoin-services-payments

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
