### PR TITLE
chore: consolidate repository permissions through team-based access

### DIFF
--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -494,8 +494,8 @@ repositories:
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: false
-    secret_scanning: false
+    secret_scanning_push_protection: true
+    secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     visibility: public

--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -161,9 +161,7 @@ repositories:
       maintain:
         - Stebalien
       push:
-        - Kubuxu
         - lordshashank
-        - rvagg
         - silent-cipher
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -172,6 +170,9 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: PR_BODY
     squash_merge_commit_title: PR_TITLE
+    teams:
+      push:
+        - filoz-fs
     visibility: public
     web_commit_signoff_required: false
   filecoin-services:
@@ -381,7 +382,6 @@ repositories:
         - frrist
         - LexLuthr
         - nijoe1
-        - rvagg
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -389,6 +389,9 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      push:
+        - filoz-fs
     visibility: public
     web_commit_signoff_required: false
   retropgf-drips:
@@ -453,8 +456,6 @@ repositories:
         - aarshkshah1992
       push:
         - silent-cipher
-        - timfong888
-        - TippyFlitsUK
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
### Summary
Closes: https://github.com/FilOzone/filecoin-services/issues/70 Consolidate repository permissions through team-based access.
- Add filoz-fs team push access to filecoin-services-payments and pdp
- Remove individual push permissions for users covered by team membership

**filecoin-services-payments**
✅ Removed Kubuxu (individual push) → Still has push via filoz-fs team
✅ Removed rvagg (individual push) → Still has push via filoz-fs team

**pdp**
✅ Removed rvagg (individual push) → Still has push via filoz-fs team

**synapse-sdk**
✅ Removed timfong888 (individual push) → Still has push via filoz-fs team
✅ Removed TippyFlitsUK (individual push) → Still has push via filoz-fs team

### Why do you need this?
Because it simplifies permission management without changing actual access levels.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
