### PR TITLE
chore: update hugo to maintain perms for synapse-sdk

### DIFF
--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -536,8 +536,8 @@ repositories:
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: false
-    secret_scanning: false
+    secret_scanning_push_protection: true
+    secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     visibility: public


### PR DESCRIPTION
### Summary
Update hugo to maintain perms for synapse-sdk, so that he can get unblocked to update websites, etc. Doing it here in GitHub-Mgmt, to record the change.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
