### PR TITLE
chore: add issues and PRs to FS project board workflow

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,34 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
+# See https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
+######################################################################################
+
+# This action adds all issues and PRs to the FS project board.
+# It is used to keep the project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - opened
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and prs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}

--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -18,17 +18,18 @@ on:
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
   # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
   # This action does not check out nor execute user code so we should be safe.
-  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  # The action is pinned to an immutable commit SHA to prevent supply-chain risk.
   pull_request_target:
     types:
       - opened
 
 jobs:
   add-to-project:
-    name: Add all issues and prs to project
+    name: Add all issues and PRs to project
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
## Summary
- add `.github/workflows/add-issues-and-prs-to-fs-project-board.yml`
- mirror the same automation pattern used in `dealbot` for adding new issues/PRs to the FS project board
- use `pull_request_target` to support PRs from forks while keeping the action pinned

## Test plan
- [x] validate workflow YAML structure and trigger blocks
- [x] verify action version and project URL match expected values

Made with [Cursor](https://cursor.com)