### PR TITLE
fix: grant FilOzzy admin access for security reports

### DIFF
--- a/github/FilOzone.yml
+++ b/github/FilOzone.yml
@@ -134,13 +134,13 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - SgtPooki
       maintain:
         - silent-cipher
       pull:
         - Chaitu-Tatipamula
       push:
-        - FilOzzy
         - juliangruber
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -386,6 +386,7 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - jennijuju
       maintain:
         - juliangruber
@@ -411,6 +412,7 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - jennijuju
         - rjan90
         - rvagg
@@ -888,6 +890,8 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
+      admin:
+        - FilOzzy
       maintain:
         - Kubuxu
       push:
@@ -965,6 +969,7 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - wjmelements
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -1013,12 +1018,12 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - rjan90
         - rvagg
       maintain:
         - hugomrdias
       push:
-        - FilOzzy
         - juliangruber
         - silent-cipher
       triage:


### PR DESCRIPTION
## Summary
- Grant `FilOzzy` admin access on the FilOzone repos covered by the FOC security reporting policy.
- Move `FilOzzy` from lower repository permissions to admin where it was already present.

## Why
Private vulnerability report notifications are sent to repository administrators/security managers with the right notification settings. `FilOzzy` routes to the shared infra inbox, giving us a shared fallback notification path for reports.

Ref: https://github.com/FilOzone/tpm-utils/issues/16#issuecomment-4665035202