### PR TITLE
ci: backport latest add-to-project workflow, rename FS -> FOC

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
@@ -1,24 +1,29 @@
 ######################################################################################
 # READ THIS FIRST
 # This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
-# See https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
+# At least as of 2025-07-16, changes to this file will not be automatically propagated.
+# This is discussed more in https://github.com/FilOzone/github-mgmt/issues/10.
+# This file resides in FilOzone/github-mgmt for visibility.
 ######################################################################################
 
-# This action adds all issues and PRs to the FS project board.
+# This action adds all issues and PRs to the FOC project board.
 # It is used to keep the project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
 # It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
 # This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
-name: Add issues and PRs to FS project board
+name: Add issues and PRs to FOC project board
 
 on:
   issues:
     types:
       - opened
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
-  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # pull_request_target has access to secrets even for fork PRs, which is necessary
+  # for this action to authenticate and add items to the project board.
+  # pull_request_target runs the workflow file from the base branch (main),
+  # not from the PR branch, so attackers cannot modify this workflow via PR.
   # This action does not check out nor execute user code so we should be safe.
-  # The action is pinned to an immutable commit SHA to prevent supply-chain risk.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
   pull_request_target:
     types:
       - opened
@@ -26,10 +31,13 @@ on:
 jobs:
   add-to-project:
     name: Add all issues and PRs to project
+    # This job authenticates with the dedicated FILOZZY_CI_ADD_TO_PROJECT PAT and does
+    # not use the default GITHUB_TOKEN, so drop all of its permissions to limit blast radius.
     permissions: {}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}

--- a/files/workflows/add-issues-and-prs-to-foc-project-board.yml
+++ b/files/workflows/add-issues-and-prs-to-foc-project-board.yml
@@ -3,22 +3,25 @@
 # This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
 # At least as of 2025-07-16, changes to this file will not be automatically propagated.
 # This is discussed more in https://github.com/FilOzone/github-mgmt/issues/10.
-# This file resides in FilOzone/github-mgmt for visibility.  
+# This file resides in FilOzone/github-mgmt for visibility.
 ######################################################################################
 
-# This action adds all issues and PRs to the FS project board.
+# This action adds all issues and PRs to the FOC project board.
 # It is used to keep the project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
 # It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
 # This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
-name: Add issues and PRs to FS project board
+name: Add issues and PRs to FOC project board
 
 on:
   issues:
     types:
       - opened
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
-  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # pull_request_target has access to secrets even for fork PRs, which is necessary
+  # for this action to authenticate and add items to the project board.
+  # pull_request_target runs the workflow file from the base branch (main),
+  # not from the PR branch, so attackers cannot modify this workflow via PR.
   # This action does not check out nor execute user code so we should be safe.
   # We also hardcode to specific hash to ensure no unintended changes underneath us.
   pull_request_target:
@@ -27,10 +30,11 @@ on:
 
 jobs:
   add-to-project:
-    name: Add all issues and prs to project
+    name: Add all issues and PRs to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}

--- a/files/workflows/add-issues-and-prs-to-foc-project-board.yml
+++ b/files/workflows/add-issues-and-prs-to-foc-project-board.yml
@@ -31,6 +31,9 @@ on:
 jobs:
   add-to-project:
     name: Add all issues and PRs to project
+    # This job authenticates with the dedicated FILOZZY_CI_ADD_TO_PROJECT PAT and does
+    # not use the default GITHUB_TOKEN, so drop all of its permissions to limit blast radius.
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0


### PR DESCRIPTION
## What

Backports the latest-and-greatest version of the "add issues and PRs to project board" workflow (the one currently running in [FilOzone/synapse-sdk](https://github.com/FilOzone/synapse-sdk/blob/master/.github/workflows/add-issues-and-prs-to-fs-project-board.yml)) into the canonical sample that lives here and is manually copied to other repos.

**Functional changes:**
- Pin `actions/add-to-project` to the v2.0.0 commit hash (was `v1.0.2`).
- Add `continue-on-error: true` so the job doesn't fail when an item is already on the board (the action doesn't handle that case gracefully).
- Expand the `pull_request_target` security-rationale comment.

**Naming cleanup** (org project #14 is the **FOC** board, not "FS"):
- `git mv` `…-to-fs-project-board.yml` → `…-to-foc-project-board.yml`.
- Update the workflow `name:` and comments to say "FOC project board".
- Capitalize the job name `prs` → `PRs` for consistency.

## Why

A recent audit found issues/PRs opened across the org that never made it onto the FOC board because several repos either lacked this workflow or ran an older/issues-only variant. While fixing those repos, the "FS" naming was flagged as confusing (by a Copilot review on [foc-gh#11](https://github.com/FilOzone/foc-gh/pull/11)) since the board is FOC. This updates the source of truth so future copies are correct and consistent.

## Note

Per the header, this file is **manually** copied to other repos, so merging this does not auto-propagate. The downstream repos being fixed in parallel ([foc-gh#11](https://github.com/FilOzone/foc-gh/pull/11), [foc-observer#74](https://github.com/FilOzone/foc-observer/pull/74), [team-skills#6](https://github.com/FilOzone/team-skills/pull/6), [security-triage#9](https://github.com/FilOzone/security-triage/pull/9)) are being updated to match this content and filename.
